### PR TITLE
Pass message which contains URL as-is to iicmd.py, add tests

### DIFF
--- a/iibot-ng
+++ b/iibot-ng
@@ -36,7 +36,7 @@ monitor()
                 export IICMD_BITLY_API_TOKEN="${bitly_api_token}"
                 exec "${ircdir}/iicmd.py" \
                     --nick "${nick}" \
-                    --message "url ${msg#* }" \
+                    --message "url ${msg#\!}" \
                     --ircd "${ircdir}" \
                     --network "${network}" \
                     --channel "${channel}" \


### PR DESCRIPTION
I found case when URL was being ignored by bot due to the fact it was being stripped. It seems to me this handling is no longer necessary.